### PR TITLE
fix(debug): create the debug loader once

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -13,8 +13,6 @@ module.exports = {
     // This is silly. Negated conditions are highly useful and often much more concise than
     // their complements.
     "no-negated-condition": "off",
-    // allow use of var
-    "no-var": "off",
     "indent": ["error", 2, {
       "MemberExpression": 1
     }]

--- a/bin/buildindex
+++ b/bin/buildindex
@@ -2,18 +2,16 @@
 
 'use strict';
 
-const bitsIndex = require('../buildindex.js');
+const index = require('../buildindex.js');
 const path = require('path');
 const yargs = require('yargs');
 
 const ARGS = yargs.usage('$0 input.js\nSee README.md for input requirements.')
-    .alias('d', 'debug')
-    .boolean('d')
-    .demand(1)
-    .wrap(80)
-    .argv;
+  .alias('d', 'debug')
+  .boolean('d')
+  .demand(1)
+  .wrap(80)
+  .argv;
 
-const indexPath = path.join(process.cwd(),
-    path.relative(process.cwd(), ARGS._[0]));
-
-bitsIndex.buildIndexFromFile(indexPath, !!ARGS.debug);
+const indexPath = path.join(process.cwd(), path.relative(process.cwd(), ARGS._[0]));
+index.buildIndexFromFile(indexPath, !!ARGS.debug);

--- a/buildindex.js
+++ b/buildindex.js
@@ -61,10 +61,10 @@ const addAppScript = function(scriptPath, template) {
  * @return {string} The modified template
  */
 const addVendorCss = function(template, inputFile) {
-  var files;
+  let files;
 
   try {
-    var fileContent = fs.readFileSync(inputFile, 'utf8');
+    const fileContent = fs.readFileSync(inputFile, 'utf8');
     files = fileContent.split('\n');
   } catch (e) {
     console.error('ERROR: failed reading vendor styles from ' + inputFile);
@@ -76,7 +76,7 @@ const addVendorCss = function(template, inputFile) {
     console.log('Adding ' + files.length + ' vendor styles from ' + inputFile);
 
     // add the application css
-    var links = files.map(function(file) {
+    const links = files.map(function(file) {
       return createLinkTag(file);
     });
 
@@ -95,10 +95,10 @@ const addVendorCss = function(template, inputFile) {
  * @return {Array<string>} The vendor scripts.
  */
 const getVendorScripts = function(inputFile) {
-  var files;
+  let files;
 
   try {
-    var fileContent = fs.readFileSync(inputFile, 'utf8');
+    const fileContent = fs.readFileSync(inputFile, 'utf8');
     files = fileContent.split('\n');
   } catch (e) {
     console.error('ERROR: failed reading vendor scripts from ' + inputFile);
@@ -116,11 +116,11 @@ const getVendorScripts = function(inputFile) {
  * @return {string} The modified template
  */
 const addVendorScripts = function(template, inputFile) {
-  var files = getVendorScripts(inputFile);
+  const files = getVendorScripts(inputFile);
   if (files && files.length > 0) {
     console.log('Adding ' + files.length + ' vendor scripts from ' + inputFile);
 
-    var scripts = files.map(function(file) {
+    const scripts = files.map(function(file) {
       return createScriptTag(file);
     });
 
@@ -134,13 +134,11 @@ const addVendorScripts = function(template, inputFile) {
   return template;
 };
 
-const buildCompiledIndex = function(options, templateOptions) {
-  var basePath = options.basePath || process.cwd();
-  var appPath = options.appPath || basePath;
-  var id = templateOptions.id;
-  var templateFile = templateOptions.file || id + '-template.html';
-  var templatePath = !path.isAbsolute(templateFile) ? path.join(basePath, templateFile) : templateFile;
-  var file = templatePath.replace(/-template.html$/, '.html');
+const buildCompiledIndex = function(options, templateOptions, basePath, appPath) {
+  const id = templateOptions.id;
+  const templateFile = templateOptions.file || id + '-template.html';
+  const templatePath = !path.isAbsolute(templateFile) ? path.join(basePath, templateFile) : templateFile;
+  const file = templatePath.replace(/-template.html$/, '.html');
 
   if (templateOptions.skip) {
     return Promise.resolve();
@@ -152,20 +150,20 @@ const buildCompiledIndex = function(options, templateOptions) {
 
   console.log('Creating compiled index from ' + file + '...');
 
-  var template = readFile(templatePath);
+  let template = readFile(templatePath);
 
   // replace application version and version path
-  var version = options.appVersion || '';
-  var packageVersion = options.overrideVersion || options.packageVersion || '';
-  var versionPath = version ? (version + path.sep) : '';
+  const version = options.appVersion || '';
+  const packageVersion = options.overrideVersion || options.packageVersion || '';
+  const versionPath = version ? (version + path.sep) : '';
   template = template.replace(/@appVersion@/g, version);
   template = template.replace(/@packageVersion@/g, packageVersion);
   template = template.replace(/@version@/g, slash(versionPath));
 
   // add vendor scripts/css
-  var vendorCssPath = path.join(appPath, '.build',
+  const vendorCssPath = path.join(appPath, '.build',
     'resources-css-dist-' + id);
-  var vendorJsPath = path.join(appPath, '.build',
+  const vendorJsPath = path.join(appPath, '.build',
     'resources-js-dist-' + id);
   template = addVendorCss(template, vendorCssPath);
   template = addVendorScripts(template, vendorJsPath);
@@ -173,7 +171,7 @@ const buildCompiledIndex = function(options, templateOptions) {
   template = addAppCss(options.compiledCss, template);
   template = addAppScript(options.compiledJs, template);
 
-  var indexPath = path.join(options.distPath, id + '.html');
+  const indexPath = path.join(options.distPath, id + '.html');
   console.log('Writing compiled index to ' + indexPath);
   console.log();
 
@@ -186,13 +184,11 @@ const buildCompiledIndex = function(options, templateOptions) {
   return Promise.resolve();
 };
 
-const buildDebugIndex = function(options, templateOptions) {
-  var basePath = options.basePath || process.cwd();
-  var appPath = options.appPath || basePath;
-  var id = templateOptions.id;
-  var templateFile = templateOptions.file || id + '-template.html';
-  var templatePath = !path.isAbsolute(templateFile) ? path.join(basePath, templateFile) : templateFile;
-  var file = templatePath.replace(/-template.html$/, '.html');
+const buildDebugIndex = function(options, templateOptions, basePath, appPath) {
+  const id = templateOptions.id;
+  const templateFile = templateOptions.file || id + '-template.html';
+  const templatePath = !path.isAbsolute(templateFile) ? path.join(basePath, templateFile) : templateFile;
+  const file = templatePath.replace(/-template.html$/, '.html');
 
   if (templateOptions.skip) {
     return Promise.resolve();
@@ -204,7 +200,7 @@ const buildDebugIndex = function(options, templateOptions) {
 
   console.log('Creating debug index from ' + file + '...');
 
-  var template = readFile(templatePath);
+  let template = readFile(templatePath);
 
   // remove version tags
   template = template.replace(/@version@/g, '');
@@ -214,52 +210,66 @@ const buildDebugIndex = function(options, templateOptions) {
   template = template.replace(/@packageVersion@/g, 'dev');
 
   // add vendor css
-  var vendorCssPath = path.join(appPath, '.build', 'resources-css-debug-' + id);
+  const vendorCssPath = path.join(appPath, '.build', 'resources-css-debug-' + id);
   template = addVendorCss(template, vendorCssPath);
 
   // add application css
   template = addAppCss(options.debugCss, template);
 
-  // generate Closure dependency file
-  var appLoaderPath = path.join(appPath, '.build', 'app-loader.js');
-  var gccArgs = require(path.join(appPath, '.build', 'gcc-args'));
+  if (template.indexOf('<!--VENDOR_JS-->') > -1) {
+    // add vendor scripts
+    const vendorJsPath = path.join(appPath, '.build', 'resources-js-debug-' + id);
+    const vendorScripts = getVendorScripts(vendorJsPath).map(createScriptTag);
 
-  return closureHelper.writeDebugLoader(gccArgs, appLoaderPath).then(function() {
-    if (template.indexOf('<!--VENDOR_JS-->') > -1) {
-      // add vendor scripts
-      var vendorJsPath = path.join(appPath, '.build', 'resources-js-debug-' + id);
-      var vendorScripts = getVendorScripts(vendorJsPath).map(createScriptTag);
+    // add the loader to the template and clear the script so it isn't added twice
+    template = template.replace('<!--VENDOR_JS-->', vendorScripts.join('\n'));
+  }
 
-      // add the loader to the template and clear the script so it isn't added twice
-      template = template.replace('<!--VENDOR_JS-->', vendorScripts.join('\n'));
-    }
+  if (template.indexOf('<!--APP_JS-->') > -1) {
+    const closureLibPath = path.dirname(require.resolve(path.join('google-closure-library', 'package.json')));
+    const closureSrcPath = path.join(closureLibPath, 'closure', 'goog');
+    const appLoaderPath = getAppLoaderPath(appPath);
 
-    if (template.indexOf('<!--APP_JS-->') > -1) {
-      var closureLibPath = path.dirname(require.resolve(path.join('google-closure-library', 'package.json')));
-      var closureSrcPath = path.join(closureLibPath, 'closure', 'goog');
+    // add GCC debug defines, Closure base/deps, and application loader
+    const appScripts = [
+      path.relative(basePath, path.join(appPath, '.build', 'gcc-defines-debug.js')),
+      path.relative(basePath, path.join(closureSrcPath, 'base.js')),
+      path.relative(basePath, path.join(closureSrcPath, 'deps.js')),
+      path.relative(basePath, appLoaderPath)
+    ].map(createScriptTag);
 
-      // add GCC debug defines, Closure base/deps, and application loader
-      var appScripts = [
-        path.relative(basePath, path.join(appPath, '.build', 'gcc-defines-debug.js')),
-        path.relative(basePath, path.join(closureSrcPath, 'base.js')),
-        path.relative(basePath, path.join(closureSrcPath, 'deps.js')),
-        path.relative(basePath, appLoaderPath)
-      ].map(createScriptTag);
+    // add the loader to the template (clears the tag if the loader was already added)
+    template = template.replace('<!--APP_JS-->', appScripts.join('\n'));
+  }
 
-      // add the loader to the template (clears the tag if the loader was already added)
-      template = template.replace('<!--APP_JS-->', appScripts.join('\n'));
-    }
+  const indexPath = path.join(basePath, id + '.html');
+  console.log('Writing debug index to ' + indexPath);
+  console.log();
 
-    var indexPath = path.join(basePath, id + '.html');
-    console.log('Writing debug index to ' + indexPath);
-    console.log();
+  fs.writeFileSync(indexPath, template);
 
-    fs.writeFileSync(indexPath, template);
+  return Promise.resolve();
+};
 
-    return Promise.resolve();
-  }, function(reason) {
-    throw new Error(`Failed writing debug loader: ${reason}`);
-  });
+/**
+ * Build the application debug loader.
+ * @param {string} basePath The base path.
+ * @return {Promise} A promise that resolves when the loader.
+ */
+const buildDebugLoader = function(basePath) {
+  const appLoaderPath = getAppLoaderPath(basePath);
+  const gccArgs = require(path.join(basePath, '.build', 'gcc-args'));
+  return closureHelper.writeDebugLoader(gccArgs, appLoaderPath);
+  ;
+};
+
+/**
+ * Get the path for the application debug loader.
+ * @param {string} basePath The base path.
+ * @return {string} The path to the loader.
+ */
+const getAppLoaderPath = function(basePath) {
+  return path.join(basePath, '.build', 'app-loader.js');
 };
 
 /**
@@ -270,18 +280,28 @@ const buildDebugIndex = function(options, templateOptions) {
  */
 const buildIndex = function(options, debugOnly) {
   if (options && options.templates) {
+    const basePath = options.basePath || process.cwd();
+    const appPath = options.appPath || basePath;
+
+    // generate each index from the templates
     return Promise.map(options.templates, function(template) {
-      var promise = buildDebugIndex(options, template);
+      // only write the debug application loader once, when processing "index"
+      const promise = template.id === 'index' && !template.skip ?
+        buildDebugLoader(appPath).then(undefined, function(reason) {
+          throw new Error(`Failed writing debug loader: ${reason}`);
+        }) : Promise.resolve();
+
+      promise.then(function() {
+        buildDebugIndex(options, template, basePath, appPath);
+      });
 
       if (!debugOnly) {
         promise.then(function() {
-          return buildCompiledIndex(options, template);
+          return buildCompiledIndex(options, template, basePath, appPath);
         });
       }
 
       return promise;
-    }, {
-      concurrency: 1
     });
   }
 
@@ -295,7 +315,7 @@ const buildIndex = function(options, debugOnly) {
  * @return {Promise} A promise that resolves when the index is ready.
  */
 const buildIndexFromFile = function(file, debugOnly) {
-  var index;
+  let index;
 
   console.log('Loading index options from ' + file);
 

--- a/karma-test-loader.js
+++ b/karma-test-loader.js
@@ -15,17 +15,17 @@
  * @see https://codereview.chromium.org/18541
  */
 (function() {
-  var MOCK_REGEXP = /\.mock\.js$/;
-  var TEST_REGEXP = /\.test\.js$/;
+  const MOCK_REGEXP = /\.mock\.js$/;
+  const TEST_REGEXP = /\.test\.js$/;
 
   // The Karma configuration must add a proxy to point this at `gcc-test-manifest`.
-  var scriptsPath = '/karma-test-scripts';
+  const scriptsPath = '/karma-test-scripts';
 
   // The resource limit error has been observed when loading ~2000 scripts, so reduce concurrency to avoid that. If the
   // limit is still reached, reduce this further.
-  var concurrencyLimit = 500;
-  var pending = 0;
-  var scripts;
+  const concurrencyLimit = 500;
+  let pending = 0;
+  let scripts;
 
   /**
    * Clear the loaded handler installed by Jasmine, so Karma can be manually started when the loader is done.
@@ -35,14 +35,14 @@
   /**
    * Load the next script in the list.
    */
-  var loadNext = function() {
-    var next = scripts.shift();
+  const loadNext = function() {
+    const next = scripts.shift();
     if (next) {
       //
       // Setting async to false ensures scripts are loaded in the order they are added to the page. When a script
       // finishes loading, move on to the next script in the list.
       //
-      var script = document.createElement('script');
+      const script = document.createElement('script');
       script.async = false;
       script.src = next;
 
@@ -65,7 +65,7 @@
     }
   };
 
-  var xhr = new XMLHttpRequest();
+  const xhr = new XMLHttpRequest();
 
   /**
    * Handle XHR load of test scripts.
@@ -80,12 +80,12 @@
       throw new Error('Failing loading test scripts: empty/unexpected response for ' + scriptsPath);
     }
 
-    var deps = [];
-    var mocks = [];
-    var tests = [];
+    const deps = [];
+    const mocks = [];
+    const tests = [];
 
     // Load source files, then mocks, then tests.
-    var files = xhr.response.split('\n');
+    const files = xhr.response.split('\n');
     files.forEach(function(file) {
       file = file.trim();
 
@@ -103,8 +103,8 @@
     pending = scripts.length;
 
     // Queue scripts, up to the concurrency limit.
-    var n = scripts.length;
-    for (var i = 0; i < n && i < concurrencyLimit; i++) {
+    const n = scripts.length;
+    for (let i = 0; i < n && i < concurrencyLimit; i++) {
       loadNext();
     }
   };

--- a/test/buildindex.test.js
+++ b/test/buildindex.test.js
@@ -133,7 +133,7 @@ const generateResourceFiles = function() {
 
     const resourcePath = fileParts.join(path.sep);
     const resources = [];
-    for (var i = 0; i < numResources; i++) {
+    for (let i = 0; i < numResources; i++) {
       resources.push(path.join(resourcePath, i + ext));
     }
 
@@ -206,7 +206,7 @@ before(function() {
 
 describe('opensphere-build-index', function() {
   describe('debug index', function() {
-    var indexFiles = {};
+    const indexFiles = {};
 
     it('generates debug index files from the templates', function() {
       expect(fs.existsSync(path.join(mockDir, 'index1.html')))
@@ -217,7 +217,7 @@ describe('opensphere-build-index', function() {
 
     it('reads the debug index', function() {
       return Promise.map(['index1.html', 'index2.html', 'noapp.html', 'novendor.html'], function(fileName) {
-        var key = fileName.replace(/\..*/, '');
+        const key = fileName.replace(/\..*/, '');
         return fs.readFileAsync(path.join(mockDir, fileName), 'utf8').then(function(file) {
           indexFiles[key] = file;
 
@@ -230,10 +230,10 @@ describe('opensphere-build-index', function() {
     });
 
     it('replaces the version strings', function() {
-      for (var key in indexFiles) {
-        var index = indexFiles[key];
-        var lines = index.split('\n');
-        var versionLine = lines.find(function(line) {
+      for (const key in indexFiles) {
+        const index = indexFiles[key];
+        const lines = index.split('\n');
+        const versionLine = lines.find(function(line) {
           return /ng-init="version='dev';versionPath=''"/.test(line);
         });
 
@@ -242,20 +242,20 @@ describe('opensphere-build-index', function() {
     });
 
     it('adds link tags to the index', function() {
-      for (var key in indexFiles) {
-        var index = indexFiles[key];
+      for (const key in indexFiles) {
+        const index = indexFiles[key];
 
-        var lines = index.split('\n');
-        var links = lines.filter(function(line) {
+        const lines = index.split('\n');
+        const links = lines.filter(function(line) {
           return /^<link /.test(line);
         });
 
-        var inspectedLinks = 0;
+        let inspectedLinks = 0;
 
         if (hasVendorTag(key)) {
-          for (var i = 0; i < numResources; i++) {
-            var linkUrl = 'resources/css/debug/' + key + '/' + i + '.css';
-            var linkTag = '<link rel="stylesheet" href="' + linkUrl + '">';
+          for (let i = 0; i < numResources; i++) {
+            const linkUrl = 'resources/css/debug/' + key + '/' + i + '.css';
+            const linkTag = '<link rel="stylesheet" href="' + linkUrl + '">';
             expect(links[i]).to.equal(linkTag, key + ' missing css file from gcc resources');
             inspectedLinks++;
           }
@@ -271,18 +271,18 @@ describe('opensphere-build-index', function() {
     });
 
     it('adds script tags to the index', function() {
-      for (var key in indexFiles) {
-        var index = indexFiles[key];
-        var lines = index.split('\n');
-        var scripts = lines.filter(function(line) {
+      for (const key in indexFiles) {
+        const index = indexFiles[key];
+        const lines = index.split('\n');
+        const scripts = lines.filter(function(line) {
           return /^<script src=/.test(line);
         });
 
-        var inspectedScripts = 0;
+        let inspectedScripts = 0;
 
         if (hasVendorTag(key)) {
-          for (var i = 0; i < numResources; i++) {
-            var scriptUrl = 'resources/js/debug/' + key + '/' + i + '.js';
+          for (let i = 0; i < numResources; i++) {
+            const scriptUrl = 'resources/js/debug/' + key + '/' + i + '.js';
             expect(scripts[i]).to.have.string(scriptUrl, key + ' missing/incorrect js file from gcc resources');
             inspectedScripts++;
           }
@@ -311,7 +311,7 @@ describe('opensphere-build-index', function() {
   });
 
   describe('distribution index', function() {
-    var indexFiles = {};
+    const indexFiles = {};
 
     it('generates distribution index files from the templates', function() {
       expect(fs.existsSync(path.join(distDir, 'index1.html')))
@@ -323,7 +323,7 @@ describe('opensphere-build-index', function() {
     it('reads the distribution index', function() {
       return Promise.map(['index1.html', 'index2.html'], function(fileName) {
         return fs.readFileAsync(path.join(distDir, fileName), 'utf8').then(function(file) {
-          var key = fileName.replace(/\.html/, '');
+          const key = fileName.replace(/\.html/, '');
           indexFiles[key] = file;
 
           return Promise.resolve();
@@ -335,10 +335,10 @@ describe('opensphere-build-index', function() {
     });
 
     it('replaces the version strings', function() {
-      for (var key in indexFiles) {
-        var index = indexFiles[key];
-        var lines = index.split('\n');
-        var versionLine = lines.find(function(line) {
+      for (const key in indexFiles) {
+        const index = indexFiles[key];
+        const lines = index.split('\n');
+        const versionLine = lines.find(function(line) {
           return /ng-init="version='test-version';versionPath='test-version\/'"/.test(line);
         });
 
@@ -347,19 +347,19 @@ describe('opensphere-build-index', function() {
     });
 
     it('adds link tags to the index', function() {
-      for (var key in indexFiles) {
-        var index = indexFiles[key];
+      for (const key in indexFiles) {
+        const index = indexFiles[key];
 
-        var lines = index.split('\n');
-        var links = lines.filter(function(line) {
+        const lines = index.split('\n');
+        const links = lines.filter(function(line) {
           return /^<link /.test(line);
         });
 
         expect(links.length).to.equal(numResources + 1, key + ' has incorrect number of link elements');
 
-        for (var i = 0; i < numResources; i++) {
-          var linkUrl = 'resources/css/dist/' + key + '/' + i + '.css';
-          var linkTag = '<link rel="stylesheet" href="' + linkUrl + '">';
+        for (let i = 0; i < numResources; i++) {
+          const linkUrl = 'resources/css/dist/' + key + '/' + i + '.css';
+          const linkTag = '<link rel="stylesheet" href="' + linkUrl + '">';
           expect(links[i]).to.equal(linkTag, key + ' missing css file from gcc resources');
         }
 
@@ -369,19 +369,19 @@ describe('opensphere-build-index', function() {
     });
 
     it('adds script tags to the index', function() {
-      for (var key in indexFiles) {
-        var index = indexFiles[key];
+      for (const key in indexFiles) {
+        const index = indexFiles[key];
 
-        var lines = index.split('\n');
-        var scripts = lines.filter(function(line) {
+        const lines = index.split('\n');
+        const scripts = lines.filter(function(line) {
           return /^<script src=/.test(line);
         });
 
         expect(scripts.length).to.equal(numResources + 1, key + ' has incorrect number of script elements');
 
-        for (var i = 0; i < numResources; i++) {
-          var scriptUrl = 'resources/js/dist/' + key + '/' + i + '.js';
-          var scriptTag = '<script src="' + scriptUrl + '"></script>';
+        for (let i = 0; i < numResources; i++) {
+          const scriptUrl = 'resources/js/dist/' + key + '/' + i + '.js';
+          const scriptTag = '<script src="' + scriptUrl + '"></script>';
           expect(scripts[i]).to.equal(scriptTag, key + ' missing/incorrect js file from gcc resources');
         }
 


### PR DESCRIPTION
Previously the loader was created once per processed template.

The app loader is generated using `gcc-args.json` for the entire application and will not change for each index. It only needs to be generated once, so we'll do that in the `index` template when `skip` is not set on the template options.

This does require the main index (or at least one index) to have the id `index`, but that's the recommended pattern for OpenSphere-based applications.