### PR TITLE
feat(debug): add debug app loader with goog.module support

### DIFF
--- a/app-loader.js
+++ b/app-loader.js
@@ -3,14 +3,22 @@
   // limit is still reached, reduce this further.
   const concurrencyLimit = 500;
 
+  //
+  // Match goog.module files. Uses the 'm' flag to support files with preceding comments, while still matching the
+  // statement from the start of a line.
+  //
+  const moduleRegex = /^goog\.module\('.*'\);/m;
+
+  //
+  // Closure Compiler manifest containing the ordered list of files to load.
+  //
+  const manifestPath = '.build/gcc-manifest';
+
   let nextIndex = 0;
   let pending = 0;
 
   let scriptsContent;
   let scriptPaths;
-
-  const moduleRegex = /\ngoog\.module\('[^']+'\);\n/;
-  const manifestPath = '.build/gcc-manifest';
 
   /**
    * Load the next script.

--- a/app-loader.js
+++ b/app-loader.js
@@ -1,0 +1,126 @@
+(function() {
+  // The resource limit error has been observed when loading ~2000 scripts, so reduce concurrency to avoid that. If the
+  // limit is still reached, reduce this further.
+  const concurrencyLimit = 500;
+
+  let nextIndex = 0;
+  let pending = 0;
+
+  let scriptsContent;
+  let scriptPaths;
+
+  const moduleRegex = /\ngoog\.module\('[^']+'\);\n/;
+  const manifestPath = '.build/gcc-manifest';
+
+  /**
+   * Load the next script.
+   */
+  const loadNext = function() {
+    const scriptIndex = nextIndex++;
+    const next = scriptPaths[scriptIndex];
+    if (next) {
+      const xhr = new XMLHttpRequest();
+      xhr.open('GET', next);
+
+      /**
+       * Handle script load.
+       * @param {ProgressEvent} e The event.
+       */
+      xhr.onload = (e) => {
+        pending--;
+
+        if (xhr.responseText) {
+          let content;
+          if (moduleRegex.test(`\n${xhr.responseText}`)) {
+            content = transformModule(xhr.responseText, next);
+          } else {
+            content = `${xhr.responseText}\n//# sourceURL=${next}\n`;
+          }
+
+          scriptsContent[scriptIndex] = content;
+
+          if (pending) {
+            // Load the next script.
+            loadNext();
+          } else {
+            scriptsContent.forEach(addToDocument);
+
+            // Dump everything for good measure.
+            scriptsContent.length = 0;
+            scriptPaths.length = 0;
+          }
+        } else {
+          throw new Error(`Failed loading script: empty/unexpected response for ${next}`);
+        }
+      };
+      /**
+       * Handle script load error.
+       */
+      xhr.onerror = () => {
+        throw new Error(`Failed loading script: XHR failed with code ${xhr.status} for ${next}`);
+      };
+      xhr.send();
+    }
+  };
+
+  /**
+   * Add script content to the document.
+   * @param {string} content The content.
+   */
+  const addToDocument = (content) => {
+    // Borrowed from goog.globalEval
+    const scriptEl = document.createElement('script');
+    scriptEl.type = 'text/javascript';
+    scriptEl.defer = false;
+    scriptEl.appendChild(document.createTextNode(content));
+    document.head.appendChild(scriptEl);
+    document.head.removeChild(scriptEl);
+  };
+
+  /**
+   * Transform goog.module content so it's loaded properly.
+   * @param {string} content The content.
+   * @param {string} path The file path.
+   * @return {string} The transformed content.
+   */
+  const transformModule = (content, path) => {
+    const jsonContent = JSON.stringify(`${content}\n//# sourceURL=${path}\n`);
+    return `goog.loadModule(${jsonContent});`;
+  };
+
+  const xhr = new XMLHttpRequest();
+
+  /**
+   * Handle manifest load.
+   * @param {ProgressEvent} e The event.
+   */
+  xhr.onload = (e) => {
+    if (!xhr.response || typeof xhr.response !== 'string') {
+      throw new Error(`Failed loading test script manifest: empty/unexpected response for  ${manifestPath}`);
+    }
+
+    scriptPaths = xhr.response.trim().split('\n').map((path) => {
+      return path.replace(/^.*\/workspace\//, '../').replace(/^.*\/node_modules\//, '../../node_modules/');
+    });
+
+    // Cache content for all scripts until everything has been loaded. This allows async XHR, but sync script loading.
+    scriptsContent = new Array(scriptPaths.length);
+    pending = scriptPaths.length;
+
+    // Queue scripts, up to the concurrency limit.
+    const n = scriptPaths.length;
+    for (let i = 0; i < n && i < concurrencyLimit; i++) {
+      loadNext();
+    }
+  };
+
+  /**
+   * Handle manifest load error.
+   */
+  xhr.onerror = () => {
+    throw new Error(`Failed loading test script manifest: XHR failed with code ${xhr.status}`);
+  };
+  xhr.open('GET', manifestPath);
+  xhr.responseType = 'text';
+  xhr.send();
+})();

--- a/app-loader.js
+++ b/app-loader.js
@@ -12,7 +12,13 @@
   //
   // Closure Compiler manifest containing the ordered list of files to load.
   //
-  const manifestPath = '.build/gcc-manifest';
+  const manifestPath = window.GCC_MANIFEST_PATH;
+  if (!manifestPath) {
+    throw new Error('Path to debug scripts was not provided!');
+  }
+
+  // remove the global before loading scripts
+  delete window.GCC_MANIFEST_PATH;
 
   let nextIndex = 0;
   let pending = 0;

--- a/buildindex.js
+++ b/buildindex.js
@@ -225,11 +225,15 @@ const buildDebugIndex = function(options, templateOptions, basePath, appPath) {
   }
 
   if (template.indexOf('<!--APP_JS-->') > -1) {
+    const debugScriptsPath = path.join(appPath, '.build', 'gcc-manifest');
+    const relativeScriptsPath = slash(path.relative(basePath, debugScriptsPath));
+
     // add GCC debug defines and application loader
     const appScripts = [
-      path.relative(basePath, path.join(appPath, '.build', 'gcc-defines-debug.js')),
-      path.relative(basePath, path.join(appPath, '.build', 'app-loader.js'))
-    ].map(createScriptTag);
+      createScriptTag(path.relative(basePath, path.join(appPath, '.build', 'gcc-defines-debug.js'))),
+      `<script>window.GCC_MANIFEST_PATH="${relativeScriptsPath}";</script>`,
+      createScriptTag(path.relative(basePath, path.join(appPath, '.build', 'app-loader.js')))
+    ];
 
     // add the loader to the template (clears the tag if the loader was already added)
     template = template.replace('<!--APP_JS-->', appScripts.join('\n'));

--- a/buildindex.js
+++ b/buildindex.js
@@ -4,7 +4,6 @@ const Promise = require('bluebird');
 const fs = require('fs');
 const mkdirp = require('mkdirp');
 const path = require('path');
-const closureHelper = require('opensphere-build-closure-helper');
 const slash = require('slash');
 
 /**
@@ -226,20 +225,10 @@ const buildDebugIndex = function(options, templateOptions, basePath, appPath) {
   }
 
   if (template.indexOf('<!--APP_JS-->') > -1) {
-    const closureLibPackage = path.join('google-closure-library', 'package.json');
-    const closureLibPath = path.dirname(require.resolve(closureLibPackage, {
-      // try cwd first to get the version required by the application
-      paths: [process.cwd(), __dirname]
-    }));
-    const closureSrcPath = path.join(closureLibPath, 'closure', 'goog');
-    const appLoaderPath = getAppLoaderPath(appPath);
-
-    // add GCC debug defines, Closure base/deps, and application loader
+    // add GCC debug defines and application loader
     const appScripts = [
       path.relative(basePath, path.join(appPath, '.build', 'gcc-defines-debug.js')),
-      path.relative(basePath, path.join(closureSrcPath, 'base.js')),
-      path.relative(basePath, path.join(closureSrcPath, 'deps.js')),
-      path.relative(basePath, appLoaderPath)
+      path.relative(basePath, path.join(appPath, '.build', 'app-loader.js'))
     ].map(createScriptTag);
 
     // add the loader to the template (clears the tag if the loader was already added)
@@ -256,27 +245,6 @@ const buildDebugIndex = function(options, templateOptions, basePath, appPath) {
 };
 
 /**
- * Build the application debug loader.
- * @param {string} basePath The base path.
- * @return {Promise} A promise that resolves when the loader.
- */
-const buildDebugLoader = function(basePath) {
-  const appLoaderPath = getAppLoaderPath(basePath);
-  const gccArgs = require(path.join(basePath, '.build', 'gcc-args'));
-  return closureHelper.writeDebugLoader(gccArgs, appLoaderPath);
-  ;
-};
-
-/**
- * Get the path for the application debug loader.
- * @param {string} basePath The base path.
- * @return {string} The path to the loader.
- */
-const getAppLoaderPath = function(basePath) {
-  return path.join(basePath, '.build', 'app-loader.js');
-};
-
-/**
  * Build index HTML files for a project.
  * @param {Object} options The index generation options.
  * @param {boolean} debugOnly If the compiled index should be skipped.
@@ -287,25 +255,19 @@ const buildIndex = function(options, debugOnly) {
     const basePath = options.basePath || process.cwd();
     const appPath = options.appPath || basePath;
 
+    // copy the debug loader to .build
+    const loaderPath = path.join(appPath, '.build', 'app-loader.js');
+    fs.copyFileSync(path.join(__dirname, 'app-loader.js'), loaderPath);
+
     // generate each index from the templates
     return Promise.map(options.templates, function(template) {
-      // only write the debug application loader once, when processing "index"
-      const promise = template.id === 'index' && !template.skip ?
-        buildDebugLoader(appPath).then(undefined, function(reason) {
-          throw new Error(`Failed writing debug loader: ${reason}`);
-        }) : Promise.resolve();
-
-      promise.then(function() {
-        buildDebugIndex(options, template, basePath, appPath);
-      });
+      buildDebugIndex(options, template, basePath, appPath);
 
       if (!debugOnly) {
-        promise.then(function() {
-          return buildCompiledIndex(options, template, basePath, appPath);
-        });
+        return buildCompiledIndex(options, template, basePath, appPath);
       }
 
-      return promise;
+      return Promise.resolve();
     });
   }
 

--- a/package.json
+++ b/package.json
@@ -67,7 +67,6 @@
   },
   "dependencies": {
     "bluebird": "^3.4.6",
-    "opensphere-build-closure-helper": "^5.0.0",
     "yargs": "^6.3.0"
   },
   "devDependencies": {
@@ -81,7 +80,6 @@
     "@semantic-release/npm": "^5.1.4",
     "@semantic-release/release-notes-generator": "^7.1.4",
     "chai": "^4.2.0",
-    "chai-spies": "^1.0.0",
     "eslint": "^6.0.0",
     "eslint-config-google": "^0.14.0",
     "husky": "^3.0.1",

--- a/test/buildindex.test.js
+++ b/test/buildindex.test.js
@@ -266,7 +266,7 @@ describe('opensphere-build-index', function() {
         const index = indexFiles[key];
         const lines = index.split('\n');
         const scripts = lines.filter(function(line) {
-          return /^<script src=/.test(line);
+          return /^<script( src|>)/.test(line);
         });
 
         let inspectedScripts = 0;
@@ -282,6 +282,9 @@ describe('opensphere-build-index', function() {
         if (hasAppTag(key)) {
           expect(scripts[inspectedScripts]).to.have.string('.build/gcc-defines-debug.js',
             key + ' missing gcc debug defines');
+          inspectedScripts++;
+
+          expect(scripts[inspectedScripts]).to.have.string('window.GCC_MANIFEST_PATH', key + ' missing manifest path');
           inspectedScripts++;
 
           expect(scripts[inspectedScripts]).to.have.string('.build/app-loader.js', key + ' missing app loader');

--- a/test/buildindex.test.js
+++ b/test/buildindex.test.js
@@ -3,14 +3,8 @@ const fs = Promise.promisifyAll(require('fs'));
 const rimraf = Promise.promisify(require('rimraf'));
 const mkdirp = Promise.promisifyAll(require('mkdirp'));
 const path = require('path');
-const closureHelper = require('opensphere-build-closure-helper');
 const osIndex = require('../buildindex.js');
-
-const chai = require('chai');
-const spies = require('chai-spies');
-chai.use(spies);
-
-const expect = chai.expect;
+const {expect} = require('chai');
 
 const mockDir = path.resolve(__dirname, 'mock');
 const modulesDir = path.join(mockDir, 'node_modules', 'test');
@@ -194,9 +188,6 @@ const generateIndex = function() {
 };
 
 before(function() {
-  // we'll mock the results instead of invoking the Closure deps writer
-  chai.spy.on(closureHelper, 'writeDebugLoader', () => Promise.resolve());
-
   return cleanMockDirectory()
     .then(generateTemplates)
     .then(generateResourceFiles)
@@ -291,14 +282,6 @@ describe('opensphere-build-index', function() {
         if (hasAppTag(key)) {
           expect(scripts[inspectedScripts]).to.have.string('.build/gcc-defines-debug.js',
             key + ' missing gcc debug defines');
-          inspectedScripts++;
-
-          expect(scripts[inspectedScripts]).to.have.string('google-closure-library/closure/goog/base.js',
-            key + ' missing gcc base.js');
-          inspectedScripts++;
-
-          expect(scripts[inspectedScripts]).to.have.string('google-closure-library/closure/goog/deps.js',
-            key + ' missing gcc deps.js');
           inspectedScripts++;
 
           expect(scripts[inspectedScripts]).to.have.string('.build/app-loader.js', key + ' missing app loader');


### PR DESCRIPTION
We switched to Closure's debug loader to add support for `goog.module` files, but that loader has issues with Chrome's concurrent request limits. Reinstate the debug loader, with support for `goog.module`.