### PR TITLE
feat(goog): add closure mixin to fix debug load of legacy modules

### DIFF
--- a/buildindex.js
+++ b/buildindex.js
@@ -283,11 +283,18 @@ const writeDebugManifest = function(id, basePath, appPath) {
   }
 
   return manifestPromise.then(function(files) {
-    const debugScriptsPath = getDebugManifestPath(id, appPath);
+    if (files) {
+      // add the Closure module loader mixin
+      const mixinPath = path.join(appPath, '.build', 'closure-mixin.js');
+      const relativeMixinPath = slash(path.relative(basePath, mixinPath));
+      files.splice(1, 0, relativeMixinPath);
 
-    // write the debug manifest to .build
-    console.log(`Writing debug manifest to ${debugScriptsPath}`);
-    fs.writeFileSync(debugScriptsPath, JSON.stringify(files));
+      const debugScriptsPath = getDebugManifestPath(id, appPath);
+
+      // write the debug manifest to .build
+      console.log(`Writing debug manifest to ${debugScriptsPath}`);
+      fs.writeFileSync(debugScriptsPath, JSON.stringify(files));
+    }
   });
 };
 
@@ -305,6 +312,10 @@ const buildIndex = function(options, debugOnly) {
     // copy the debug loader to .build
     const loaderPath = path.join(appPath, '.build', 'app-loader.js');
     fs.copyFileSync(path.join(__dirname, 'app-loader.js'), loaderPath);
+
+    // copy the closure module loader mixin to .build
+    const mixinPath = path.join(appPath, '.build', 'closure-mixin.js');
+    fs.copyFileSync(path.join(__dirname, 'closure-mixin.js'), mixinPath);
 
     // generate each index from the templates
     return Promise.map(options.templates, function(template) {

--- a/closure-mixin.js
+++ b/closure-mixin.js
@@ -1,0 +1,42 @@
+/* eslint-disable */
+/**
+ * Closure's goog.module.declareLegacyNamespace behavior does not handle the case where a parent namespace is loaded
+ * after a child namespace. When the parent is loaded, it will be blindly assigned to window.<namespace> which will
+ * wipe out anything previously assigned by child namespaces.
+ *
+ * Example:
+ *   - "os.ns" is loaded, which defines window.os.ns = <exports>.
+ *   - "os" is loaded, which defines window.os = <exports>. window.os.ns is now gone.
+ *
+ * This problem only impacts modules that need legacy support.
+ */
+(function() {
+  var getExistingExports = function() {
+    if (goog.moduleLoaderState_.moduleName) {
+      var moduleParts = goog.moduleLoaderState_.moduleName.split('.');
+      var current = window;
+      while (moduleParts.length && current.hasOwnProperty(moduleParts[0])) {
+        current = current[moduleParts.shift()];
+        if (!moduleParts.length) {
+          return current;
+        }
+      }
+    }
+    return undefined;
+  };
+
+  goog.loadModuleFromSource_ = /** @type {function(string):?} */ (function() {
+    'use strict';
+    var exports = {};
+    eval(arguments[0]);
+    // if declareLegacyNamespace was called, the module's exports will be set at the module's namespace on the global
+    // window object. if that object already exists, merge the exports into it and set that as the exports.
+    var __existingExports__ = getExistingExports();
+    if (goog.moduleLoaderState_.declareLegacyNamespace && __existingExports__ &&
+        Object.getPrototypeOf(exports) === Object.prototype) {
+      Object.assign(__existingExports__, exports);
+      exports = __existingExports__;
+    }
+    return exports;
+  });
+})();


### PR DESCRIPTION
`goog.module.declareLegacyNamespace` has a major flaw when loading nested namespaces. If a child namespace is loaded before the parent, the parent will wipe out the legacy namespace assigned to `window` by its children.

To reproduce, run this from `opensphere-jscodeshift`:
```
yarn run shift -t src/transforms/es6/providetomodule.js ../opensphere/src/os/events/events.js
```

Then load the debug build of OpenSphere. You'll see a pile of errors caused by `os.events` loading after several of its children, which assigns `window.os.events` to the module exports. The fix merges these objects instead of doing a simple assignment. This only impacts the debug build.